### PR TITLE
fix(sbi): use `(1, hartid)` for mask-base pair in `send_ipi` primitive, instead of `1 << hartid, 0`

### DIFF
--- a/NoAxiom/lib/arch/src/rv64/sbi.rs
+++ b/NoAxiom/lib/arch/src/rv64/sbi.rs
@@ -18,7 +18,7 @@ impl ArchSbi for RV64 {
     }
     // send ipi
     fn send_ipi(hartid: usize) {
-        sbi_rt::send_ipi(HartMask::from_mask_base(1 << hartid, 0));
+        sbi_rt::send_ipi(HartMask::from_mask_base(0b1, hartid));
     }
     // clear ipi
     fn clear_ipi() {


### PR DESCRIPTION
This modification prevents logic shift overflow when `hartid` >= `XLEN`.

Ref: https://github.com/hermit-os/kernel/pull/1088